### PR TITLE
Add support for Bearer authentication, to be used in Fir-generation runtime

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,15 @@
+version: 2.1
+
+jobs:
+  test:
+    docker:
+      - image: cimg/ruby:2.7.4
+    steps:
+      - checkout
+      - run: bundle install
+      - run: bundle exec rspec
+
+workflows:
+  test:
+    jobs:
+      - test

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ test/tmp
 test/version_tmp
 tmp
 .tags
+.idea

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,0 @@
-language: ruby
-rvm:
-  - 2.0.0
-  - 2.3.1
-script: bundle exec rspec

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,2 @@
+# Comment line immediately above ownership line is reserved for related gus information. Please be careful while editing.
+#ECCN:Open Source

--- a/lib/logplex/publisher.rb
+++ b/lib/logplex/publisher.rb
@@ -9,9 +9,10 @@ module Logplex
                       Excon::Errors::Unauthorized,
                       Timeout::Error].freeze
 
-    def initialize(logplex_url = nil)
+    def initialize(logplex_url = nil, bearer_token: nil)
       @logplex_url = logplex_url || Logplex.configuration.logplex_url
       @token = URI(@logplex_url).password || Logplex.configuration.app_name
+      @auth_headers = bearer_token ? { 'Authorization' => "Bearer #{bearer_token}" } : {}
     end
 
     def publish(messages, opts={})
@@ -36,11 +37,11 @@ module Logplex
     private
 
     def api_post(message, number_messages)
-      Excon.post(@logplex_url, body: message, headers: {
+      Excon.post(@logplex_url, body: message, headers: @auth_headers.merge({
         "Content-Type" => 'application/logplex-1',
         "Content-Length" => message.length,
         "Logplex-Msg-Count" => number_messages
-      }, expects: [200, 202, 204])
+      }), expects: [200, 202, 204])
     end
   end
 end

--- a/lib/logplex/publisher.rb
+++ b/lib/logplex/publisher.rb
@@ -19,7 +19,7 @@ module Logplex
       unless messages.is_a? Array
         message_list = [message_list]
       end
-      message_list.map! { |m| Message.new(m, opts.merge(app_name: @token)) }
+      message_list.map! { |m| Message.new(m, { app_name: @token }.merge(opts)) }
       message_list.each(&:validate)
       if message_list.inject(true) { |accum, m| m.valid? }
         begin

--- a/lib/logplex/publisher.rb
+++ b/lib/logplex/publisher.rb
@@ -40,7 +40,7 @@ module Logplex
         "Content-Type" => 'application/logplex-1',
         "Content-Length" => message.length,
         "Logplex-Msg-Count" => number_messages
-      }, expects: [200, 204])
+      }, expects: [200, 202, 204])
     end
   end
 end

--- a/lib/logplex/version.rb
+++ b/lib/logplex/version.rb
@@ -1,3 +1,3 @@
 module Logplex
-  VERSION = "0.0.5".freeze
+  VERSION = "0.0.6".freeze
 end

--- a/lib/logplex/version.rb
+++ b/lib/logplex/version.rb
@@ -1,3 +1,3 @@
 module Logplex
-  VERSION = "0.0.3".freeze
+  VERSION = "0.0.4".freeze
 end

--- a/lib/logplex/version.rb
+++ b/lib/logplex/version.rb
@@ -1,3 +1,3 @@
 module Logplex
-  VERSION = "0.0.4".freeze
+  VERSION = "0.0.5".freeze
 end

--- a/logplex.gemspec
+++ b/logplex.gemspec
@@ -6,11 +6,11 @@ require 'logplex/version'
 Gem::Specification.new do |gem|
   gem.name          = "logplex"
   gem.version       = Logplex::VERSION
-  gem.authors       = ["Harold Giménez"]
+  gem.authors       = ["Harold Giménez", "Heroku"]
   gem.email         = ["harold.gimenez@gmail.com"]
   gem.description   = "Publish and Consume Logplex messages"
   gem.summary       = "Publish and Consume Logplex messages"
-  gem.homepage      = "https://practiceovertheory.com"
+  gem.homepage      = "https://github.com/heroku/logplex-gem"
 
   gem.files         = `git ls-files`.split($/)
   gem.executables   = gem.files.grep(%r{^bin/}).map{ |f| File.basename(f) }

--- a/spec/logplex/publisher_spec.rb
+++ b/spec/logplex/publisher_spec.rb
@@ -29,13 +29,24 @@ describe Logplex::Publisher do
       end
 
       it 'sends many messages in one request when passed an array' do
-        Excon.stub({ method: :post, password: "t.some-token", body: /here is another/ }, status: 204)
-        expect(Excon).to receive(:post).once
+        Excon.stub({ method: :post, password: "t.some-token", body: /message for you.+here is another.+some final thoughts/ }, status: 204)
         messages = ['I have a message for you', 'here is another', 'some final thoughts']
-
         publisher = Logplex::Publisher.new('https://token:t.some-token@logplex.example.com')
-
         publisher.publish(messages)
+      end
+
+      it 'uses the token if app_name is not given' do
+        Excon.stub({ method: :post, password: "t.some-token", body: /t.some-token/ }, status: 204)
+        message = 'I have a message for you'
+        publisher = Logplex::Publisher.new('https://token:t.some-token@logplex.example.com')
+        publisher.publish(message)
+      end
+
+      it 'uses the given app_name' do
+        Excon.stub({ method: :post, password: "t.some-token", body: /foo/ }, status: 204)
+        message = 'I have a message for you'
+        publisher = Logplex::Publisher.new('https://token:t.some-token@logplex.example.com')
+        publisher.publish(message, app_name: 'foo')
       end
 
       it 'does the thing' do

--- a/spec/logplex/publisher_spec.rb
+++ b/spec/logplex/publisher_spec.rb
@@ -102,5 +102,17 @@ describe Logplex::Publisher do
       expect(Excon).to receive(:post).with(any_args, hash_including(:headers => headers))
       Logplex::Publisher.new('https://token:t.some-token@logplex.example.com').publish(message)
     end
+
+    it "supports bearer authentication" do
+      message = 'hello-bearer'
+      headers = {
+        "Authorization" => 'Bearer test-bearer-token',
+        "Content-Type" => 'application/logplex-1',
+        "Content-Length" => 70,
+        "Logplex-Msg-Count" => 1
+      }
+      expect(Excon).to receive(:post).with(any_args, hash_including(:headers => headers))
+      Logplex::Publisher.new('https://logplex-next.example.com', bearer_token: 'test-bearer-token').publish(message)
+    end
   end
 end

--- a/spec/logplex/publisher_spec.rb
+++ b/spec/logplex/publisher_spec.rb
@@ -56,6 +56,13 @@ describe Logplex::Publisher do
         expect(publisher.publish(message)).to be_truthy
       end
 
+      it 'does the thing with a 202' do
+        Excon.stub({ method: :post, password: "t.some-token", body: /hi\="there\"/ }, status: 202)
+        message = { hi: 'there' }
+        publisher = Logplex::Publisher.new('https://token:t.some-token@logplex.example.com')
+        expect(publisher.publish(message)).to be_truthy
+      end
+
       it 'returns true' do
         Excon.stub({ method: :post, password: "t.some-token" }, status: 204)
         message = 'I have a message for you'


### PR DESCRIPTION
Fir-generation logplex endpoints require Bearer authentication with JWT tokens that identify the underlying log generator.
